### PR TITLE
DEV-2548 : update Sdk tests for aggregation calls

### DIFF
--- a/lusid-sdk-python/tests/finbournetest.py
+++ b/lusid-sdk-python/tests/finbournetest.py
@@ -636,14 +636,14 @@ class TestFinbourneApi(TestCase):
                 agg_holdings[key] = [sum(tup) for tup in list(zip(*holdings))]
                 # Change format to a list containing a tuple to match our records with only one holding
                 agg_holdings[key] = [(agg_holdings[key][0], agg_holdings[key][1])]
-
+						
         # Iterate over our aggregated results
         for agg_record in aggregated_response.data:
             # Select our aggregated holding
             agg_holding = agg_holdings[agg_record['Holding/default/SubHoldingKey']]
             # Ensure that the units and cost match
-            self.assertEqual(agg_record['Holding/default/Units'], agg_holding[0][0])
-            self.assertEqual(agg_record['Holding/default/Cost'], agg_holding[0][1])
+            self.assertEqual(agg_record['Sum(Holding/default/Units)'], agg_holding[0][0])
+            self.assertEqual(agg_record['Sum(Holding/default/Cost)'], agg_holding[0][1])
 
 if __name__ == '__main__':
     unittest.main()

--- a/lusid-sdk-python/tests/test_transparency_strategies.py
+++ b/lusid-sdk-python/tests/test_transparency_strategies.py
@@ -558,7 +558,11 @@ class TransparencyStrategies(TestFinbourneApi):
                                                                                  op='sum'),
                                                             models.AggregateSpec(key='Holding/default/Cost',
                                                                                  op='sum')
-                                                            ])
+                                                            ],
+                                                        group_by=[
+														    'Holding/default/SubHoldingKey'
+														],														
+															)
 
         # Call LUSID to aggregate across all of our portfolios
         aggregated_group = self.client.get_aggregation_by_group(scope=self.internal_scope_code,
@@ -652,12 +656,17 @@ class TransparencyStrategies(TestFinbourneApi):
         aggregation_request = models.AggregationRequest(recipe_id=models.ResourceId(scope=self.internal_scope_code,
                                                                                     code='default'),
                                                         effective_at=datetime.now(pytz.UTC).isoformat(),
-                                                        metrics=[models.AggregateSpec(key='Holding/default/Units',
-                                                                                      op='sum'),
-                                                                 models.AggregateSpec(key='Holding/default/Cost',
-                                                                                      op='sum')],
-                                                        group_by=[self.strategy_property_key,
-                                                                  'Instrument/default/Name'],
+                                                        metrics=[
+                                                            models.AggregateSpec(key='Instrument/default/Name', op='value'),
+                                                            models.AggregateSpec(self.strategy_property_key, op='value'),
+                                                            models.AggregateSpec(key='Holding/default/SubHoldingKey', op='value'),
+															models.AggregateSpec(key='Holding/default/Units', op='sum'),
+                                                            models.AggregateSpec(key='Holding/default/Cost', op='sum')
+														],
+                                                        group_by=[
+														    self.strategy_property_key,
+                                                            'Instrument/default/Name'
+														],
                                                         filters=[
                                                             models.PropertyFilter(
                                                                 left=self.strategy_property_key,


### PR DESCRIPTION
Sdk now returns aggregate spec that was given in the request for the column rather than the property key. This means that it is simple to distinguish columns when multiple operations are performed. 