### PR TITLE
[PoC] Make rest.request resilient to 502 Gateway Errors

### DIFF
--- a/sdk/lusid/rest.py
+++ b/sdk/lusid/rest.py
@@ -108,7 +108,7 @@ class RESTClientObject(object):
 
     def request(self, method, url, query_params=None, headers=None,
                 body=None, post_params=None, _preload_content=True,
-                _request_timeout=None):
+                _request_timeout=None, retries=3):
         """Perform requests.
 
         :param method: http request method
@@ -126,7 +126,11 @@ class RESTClientObject(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
+        :param retries: times to reattempt the request if transient errors are
+                        encountered (HTTP Error 502)
         """
+        argument_cache = locals()
+        
         method = method.upper()
         assert method in ['GET', 'HEAD', 'DELETE', 'POST', 'PUT',
                           'PATCH', 'OPTIONS']
@@ -221,6 +225,11 @@ class RESTClientObject(object):
             # log response body
             logger.debug("response body: %s", r.data)
 
+        if retries and (r.status in {502}):
+            logger.debug("Temporary HTTP Error %s encountered, trying again", r.status)
+            argument_cache['retries'] -= 1
+            return self.request(**argument_cache)
+        
         if not 200 <= r.status <= 299:
             raise ApiException(http_resp=r)
 


### PR DESCRIPTION
# Pull Request Checklist

- [x] Read the [contributing guidelines](../blob/master/docs/CONTRIBUTING.md)
- [ ] Tests pass
- [x] Raised the PR against the `develop` branch

# Description of the PR

Occassionally when making a report using Lusid data, a gateway error will interrupt the entire report.
Instead of making the ApiException try excepts in our codebase even more egregious, I thought to solve the problem closer to the source, by allowing rest to recursively call itself up to 3 times when a 502 is encountered.
Naturally, on the third failed 502 call, an ApiException will be raised as normal, and the "response time" for a 502 is sufficiently small, so the tradeoff on performance/reliability is worth it.