### PR TITLE
Revert "CTECH-1344: Removes dependency that is causing test failures."

### DIFF
--- a/sdk/requirements.txt
+++ b/sdk/requirements.txt
@@ -6,3 +6,4 @@ urllib3 >= 1.15.1
 pytz >= 2019.1
 requests >= 2.21.0
 lusidfeature
+finbourne-sdk-utilities


### PR DESCRIPTION
Reverts finbourne/lusid-sdk-python#100

test failures were linked to generators not the removal of this package.